### PR TITLE
chore: called the wrong func

### DIFF
--- a/packages/api/migrations/1570007431796_drone-trips.js
+++ b/packages/api/migrations/1570007431796_drone-trips.js
@@ -23,4 +23,7 @@ exports.up = pgm => {
   })
 }
 
-exports.down = pgm => pgm.dropTable('drone_trips') && pgm.deleteType('status')
+exports.down = async pgm => {
+  await pgm.dropTable('drone_trips')
+  await pgm.dropType('status')
+}


### PR DESCRIPTION
Called the wrong drop func for migrations and it didnt throw an error