### PR TITLE
chore: 🤖 configuration to make elasticsearch production ready

### DIFF
--- a/k8s/elasticsearch.yaml
+++ b/k8s/elasticsearch.yaml
@@ -19,6 +19,44 @@ spec:
       labels:
         component: elasticsearch
     spec:
+      initContainers:
+      # NOTE:
+      # This is to fix the permission on the volume
+      # By default elasticsearch container is not run as
+      # non root user.
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_notes_for_production_use_and_defaults
+      - name: fix-the-volume-permission
+        image: busybox
+        command:
+        - sh
+        - -c
+        - chown -R 1000:1000 /usr/share/elasticsearch/data
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: elasticsearch-data
+          mountPath: /usr/share/elasticsearch/data
+      # NOTE:
+      # To increase the default vm.max_map_count to 262144
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode
+      - name: increase-the-vm-max-map-count
+        image: busybox
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      # To increase the ulimit
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_notes_for_production_use_and_defaults
+      - name: increase-the-ulimit
+        image: busybox
+        command:
+        - sh
+        - -c
+        - ulimit -n 65536
+        securityContext:
+          privileged: true
       containers:
         - name: elasticsearch
           image: docker.elastic.co/elasticsearch/elasticsearch:7.3.1
@@ -31,7 +69,7 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: elasticsearch-data
-              mountPath: 'data'
+              mountPath: /usr/share/elasticsearch/data
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
**Intent:**
most important it fixes persistence of data

**How to test:**

- After applying these changes and getting a new elasticsearch pod insert some documents into elastic.
- Verify the documents are there: (you might need to specify the namespace where you run it)
```bash
kubectl exec -it elasticsearch-0 curl localhost:9200/_cat/indices?v
```
- Simulate a destruction of the pod by removing it: (you might need to specify the namespace where you run it)
```bash
kubectl delete pod elasticsearch-0
```

- Wait for elasticsearch to startup and reindex and validate the indices and documents are still there by running the same above command:
```bash
kubectl exec -it elasticsearch-0 curl localhost:9200/_cat/indices?v
```

