### PR TITLE
refactor: bookings start

### DIFF
--- a/packages/app/src/components/form/InputSelect.tsx
+++ b/packages/app/src/components/form/InputSelect.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import styled from 'styled-components/native'
 import { View, StyleSheet } from 'react-native'
-import { Destination } from '~/__generated__/app'
+import { Destination, DestinationInput } from '~/__generated__/app'
 import RNPickerSelect from 'react-native-picker-select'
 import Label from '~/components/form/Label'
 import theme from '~/styles/theme'
+
 interface InputSelectProps {
   name?: string
   label: string
   selectOptions?: Destination[]
-  callback: (value: string) => void
+  callback: (value: DestinationInput) => void
   placeholder: string
 }
 
@@ -18,7 +19,7 @@ const InputSelectWrapper = styled(View)`
   align-items: flex-start;
 `
 
-const InputSelect: React.FC<InputSelectProps> = ({
+const GeoSelect: React.FC<InputSelectProps> = ({
   selectOptions = [],
   callback,
   label,
@@ -31,13 +32,25 @@ const InputSelect: React.FC<InputSelectProps> = ({
     value: alias,
   })
 
+  const handleChange = (input: string) => {
+    const selectOption = selectOptions.find(({ alias }) => alias === input)
+    if (selectOption) {
+      const { alias, lat, lon } = selectOption // strip __typename prop
+
+      callback({ alias, lat, lon })
+    }
+  }
+
   return (
     <InputSelectWrapper>
       <Label value={label} />
       <RNPickerSelect
-        placeholder={{ label: placeholder, value: null }}
-        onValueChange={val => callback(val)}
-        items={selectOptions?.map(toSelectItem)}
+        placeholder={{
+          label: placeholder,
+          value: null,
+        }}
+        onValueChange={handleChange}
+        items={selectOptions.map(toSelectItem)}
         style={PickerStyle}
       />
     </InputSelectWrapper>
@@ -63,4 +76,4 @@ const PickerStyle = StyleSheet.create({
   },
 })
 
-export default InputSelect
+export default GeoSelect

--- a/packages/app/src/components/form/Select.tsx
+++ b/packages/app/src/components/form/Select.tsx
@@ -6,11 +6,11 @@ import RNPickerSelect from 'react-native-picker-select'
 import Label from '~/components/form/Label'
 import theme from '~/styles/theme'
 
-interface InputSelectProps {
+interface InputSelectProps<T = any> {
   name?: string
   label: string
   selectOptions?: Destination[]
-  callback: (value: DestinationInput) => void
+  callback: (value: T) => void
   placeholder: string
 }
 
@@ -19,7 +19,7 @@ const InputSelectWrapper = styled(View)`
   align-items: flex-start;
 `
 
-const GeoSelect: React.FC<InputSelectProps> = ({
+const Geo: React.FC<InputSelectProps<DestinationInput>> = ({
   selectOptions = [],
   callback,
   label,
@@ -76,4 +76,4 @@ const PickerStyle = StyleSheet.create({
   },
 })
 
-export default GeoSelect
+export default { Geo }

--- a/packages/app/src/views/Booking/Start.tsx
+++ b/packages/app/src/views/Booking/Start.tsx
@@ -5,6 +5,7 @@ import {
   Mutation,
   Destination,
   Query,
+  DestinationInput,
 } from '~/__generated__/app'
 import { INIT_DRONE } from '~/graphql/mutations'
 import { GET_ALL_DESTINATIONS } from '~/graphql/queries'
@@ -27,12 +28,14 @@ interface BookProps {
 const SelectContainer = styled.View`
   width: 100%;
 `
+interface FormProps {
+  start?: DestinationInput
+  stop?: DestinationInput
+}
 
 const Book: React.FC<BookProps> = ({ navigation }) => {
   const { data } = useQuery<Query, Destination>(GET_ALL_DESTINATIONS)
-  const [startValue, setStartValue] = React.useState<string>('')
-
-  const [stopValue, setStopValue] = React.useState<string>('')
+  const [form, setForm] = React.useState<FormProps>({})
 
   const [initDrone] = useMutation<Mutation['initDrone'], MutationInitDroneArgs>(
     INIT_DRONE,
@@ -41,11 +44,17 @@ const Book: React.FC<BookProps> = ({ navigation }) => {
     }
   )
 
+  const formDispatcher = (type: string) => (val: DestinationInput) =>
+    form && setForm({ ...form, [type]: val })
+
   const handleDestination = () => {
-    const start = data?.allDestinations.filter(a => a.alias === startValue)
-    const stop = data?.allDestinations.filter(b => b.alias === stopValue)
-    if (start && stop) {
-      initDrone({ variables: { start: start[0], stop: stop[0] } })
+    if (form && form.start && form.stop) {
+      initDrone({
+        variables: {
+          start: form.start,
+          stop: form.stop,
+        },
+      })
     }
   }
 
@@ -59,17 +68,15 @@ const Book: React.FC<BookProps> = ({ navigation }) => {
         <SelectContainer>
           <InputSelect
             label="Från"
-            name={startValue}
             placeholder="Ange startposition"
             selectOptions={data?.allDestinations}
-            callback={setStartValue}
+            callback={formDispatcher('start')}
           />
 
           <InputSelect
             label="Till"
-            name={stopValue}
             selectOptions={data?.allDestinations}
-            callback={setStopValue}
+            callback={formDispatcher('stop')}
             placeholder="Ange destination"
           />
         </SelectContainer>

--- a/packages/app/src/views/Booking/Start.tsx
+++ b/packages/app/src/views/Booking/Start.tsx
@@ -11,7 +11,7 @@ import { INIT_DRONE } from '~/graphql/mutations'
 import { GET_ALL_DESTINATIONS } from '~/graphql/queries'
 import PrimaryButton from '~/components/Button'
 import ScrollableLayout from '~/components/ScrollableLayout'
-import InputSelect from '~/components/form/InputSelect'
+import Select from '~/components/form/Select'
 import ButtonWrapper from '~/components/ButtonWrapper'
 import ContentWrapper from '~/components/ContentWrapper'
 import TripIcon from '~/assets/Trip'
@@ -66,14 +66,14 @@ const Book: React.FC<BookProps> = ({ navigation }) => {
           <TripIcon />
         </BookingHeader>
         <SelectContainer>
-          <InputSelect
+          <Select.Geo
             label="Från"
             placeholder="Ange startposition"
             selectOptions={data?.allDestinations}
             callback={formDispatcher('start')}
           />
 
-          <InputSelect
+          <Select.Geo
             label="Till"
             selectOptions={data?.allDestinations}
             callback={formDispatcher('stop')}


### PR DESCRIPTION
**Intent:**
- Rename InputSelect to Geoselect as it's handling "Destination" types and is therefore not very reusable
- move responsibility of getting the whole destination object into the callback to Geoselect, to clean Start.tsx a bit.
- Use generic type in InputSelectProps to generalise the interface for different parameter types for the callback

- Use one setstate with the whole form instead of two, to clean up a bit.

